### PR TITLE
added support for audience

### DIFF
--- a/pkg/auth/config.go
+++ b/pkg/auth/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	DeviceAuthorizationEndpoint string                  `json:"auth_url" validate:"required,url"`
 	TokenEndpoint               string                  `json:"token_url" validate:"required,url"`
 	Scopes                      []string                `json:"scopes" validate:"required,min=1,dive,required"`
+	Audience                    string                  `json:"audience,omitempty"`
 	StorageProvider             storage.StorageProvider `json:"-"` // not validated
 }
 
@@ -54,6 +55,12 @@ func WithDeviceAuthorizationEndpoint(deviceAuthorizationEndpoint string) Option 
 func WithScopes(scopes []string) Option {
 	return func(c *Config) {
 		c.Scopes = scopes
+	}
+}
+
+func WithAudience(audience string) Option {
+	return func(c *Config) {
+		c.Audience = audience
 	}
 }
 

--- a/pkg/auth/device_code.go
+++ b/pkg/auth/device_code.go
@@ -31,6 +31,11 @@ func FetchDeviceCode(ctx context.Context, config Config) (*DeviceAuthResponse, e
 		"scope":     joinScopes(config.Scopes),
 	}
 
+	// Add optional audience
+	if config.Audience != "" {
+		payload["audience"] = config.Audience
+	}
+
 	// Add optional client secret
 	if config.ClientSecret != "" {
 		payload["client_secret"] = config.ClientSecret


### PR DESCRIPTION
Hi,

Love the package, very useful ! 

I'm using Auth0 and I needed to pass the audience field in the device_code request, so my token have the right audience.

Here's the PR allowing an optional audience with a "WithAudience" method in the options :)

Feel free to tell me if something's not right but it works with my Auth0 implementation 