### PR TITLE
Added pointer support for dynamic config

### DIFF
--- a/examples/basic/cmd/root.go
+++ b/examples/basic/cmd/root.go
@@ -30,7 +30,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const CLIENT_ID = "my-client-id"
+var CLIENT_ID = "my-client-id"
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -57,9 +57,9 @@ func init() {
 	storageProvider := storage.NewKeyringStorage(CLIENT_ID)
 
 	options := []auth.Option{
-		auth.WithDiscoveryURL(*discoveryUrl),
-		auth.WithClientID(CLIENT_ID),
-		auth.WithStorageProvider(storageProvider),
+		auth.WithDiscoveryURL(discoveryUrl),
+		auth.WithClientID(&CLIENT_ID),
+		auth.WithStorageProvider(&storageProvider),
 	}
 
 	rootCmd.AddCommand(

--- a/examples/client_credentials/cmd/root.go
+++ b/examples/client_credentials/cmd/root.go
@@ -30,8 +30,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const CLIENT_ID = "my-client-id"
-const CLIENT_SECRET = "my-client-secret"
+var CLIENT_ID = "my-client-id"
+var CLIENT_SECRET = "my-client-secret"
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -57,12 +57,13 @@ func init() {
 
 	storageProvider := storage.NewKeyringStorage(CLIENT_ID)
 
+	grantType := auth.ClientCredentials
 	options := []auth.Option{
-		auth.WithDiscoveryURL(*discoveryUrl),
-		auth.WithGrantType(auth.ClientCredentials), // Use the client credentials grant type
-		auth.WithClientID(CLIENT_ID),
-		auth.WithClientSecret(CLIENT_SECRET),
-		auth.WithStorageProvider(storageProvider),
+		auth.WithDiscoveryURL(discoveryUrl),
+		auth.WithGrantType(&grantType), // Use the client credentials grant type
+		auth.WithClientID(&CLIENT_ID),
+		auth.WithClientSecret(&CLIENT_SECRET),
+		auth.WithStorageProvider(&storageProvider),
 	}
 
 	rootCmd.AddCommand(

--- a/pkg/auth/access_token.go
+++ b/pkg/auth/access_token.go
@@ -20,13 +20,13 @@ type AccessTokenResponse struct {
 func PollForAccessToken(ctx context.Context, config Config, deviceCode string, timeout time.Duration, interval time.Duration) (*AccessTokenResponse, error) {
 	// Serialize the payload to form-encoded format
 	payload := url.Values{
-		"client_id":   []string{config.ClientId},
+		"client_id":   []string{*config.ClientId},
 		"device_code": []string{deviceCode},
 		"grant_type":  []string{DeviceCode.String()},
 	}
 
-	if config.ClientSecret != "" {
-		payload.Set("client_secret", config.ClientSecret)
+	if config.ClientSecret != nil {
+		payload.Set("client_secret", *config.ClientSecret)
 	}
 
 	// Execute the HTTP request
@@ -42,7 +42,7 @@ func PollForAccessToken(ctx context.Context, config Config, deviceCode string, t
 			return nil, fmt.Errorf("%w: timed out waiting for user authorization", ErrTokenExpired)
 		default:
 			// Create HTTP request
-			req, err := http.NewRequestWithContext(ctx, http.MethodPost, config.TokenEndpoint, bytes.NewBufferString(payload.Encode()))
+			req, err := http.NewRequestWithContext(ctx, http.MethodPost, *config.TokenEndpoint, bytes.NewBufferString(payload.Encode()))
 			if err != nil {
 				return nil, fmt.Errorf("%w: failed to create HTTP request", ErrInternal)
 			}
@@ -74,7 +74,7 @@ func PollForAccessToken(ctx context.Context, config Config, deviceCode string, t
 		case http.StatusForbidden:
 			return nil, fmt.Errorf("%w: %s", ErrSlowDown, string(body))
 		default:
-			fmt.Printf("url: %s", config.TokenEndpoint)
+			fmt.Printf("url: %s", *config.TokenEndpoint)
 			return nil, fmt.Errorf("unexpected HTTP status %d: %s", resp.StatusCode, string(body))
 		}
 	}

--- a/pkg/auth/access_token_test.go
+++ b/pkg/auth/access_token_test.go
@@ -41,9 +41,9 @@ func TestPollForAccessToken(t *testing.T) {
 			defer server.Close()
 
 			config := Config{
-				ClientId:      "test_client_id",
-				ClientSecret:  "test_client_secret",
-				TokenEndpoint: server.URL,
+				ClientId:      strPtr("test_client_id"),
+				ClientSecret:  strPtr("test_client_secret"),
+				TokenEndpoint: &server.URL,
 			}
 
 			ctx := context.Background()
@@ -63,4 +63,8 @@ func TestPollForAccessToken(t *testing.T) {
 			}
 		})
 	}
+}
+
+func strPtr(s string) *string {
+	return &s
 }

--- a/pkg/auth/client_credentials.go
+++ b/pkg/auth/client_credentials.go
@@ -13,20 +13,20 @@ import (
 func FetchClientCredentialsToken(ctx context.Context, config Config) (*AccessTokenResponse, error) {
 	// Serialize the payload to form-encoded format
 	payload := url.Values{
-		"client_id":     []string{config.ClientId},
-		"client_secret": []string{config.ClientSecret},
+		"client_id":     []string{*config.ClientId},
+		"client_secret": []string{*config.ClientSecret},
 		"grant_type":    []string{ClientCredentials.String()},
-		"scope":         []string{joinScopes(config.Scopes)},
+		"scope":         []string{joinScopes(*config.Scopes)},
 	}
 
 	// Add optional audience
-	if config.Audience != "" {
-		payload.Set("audience", config.Audience)
+	if config.Audience != nil {
+		payload.Set("audience", *config.Audience)
 	}
 
 	// Execute the HTTP request
 	client := &http.Client{Timeout: 15 * time.Second}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, config.TokenEndpoint, bytes.NewBufferString(payload.Encode()))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, *config.TokenEndpoint, bytes.NewBufferString(payload.Encode()))
 	if err != nil {
 		return nil, fmt.Errorf("%w: failed to create HTTP request", ErrInternal)
 	}

--- a/pkg/auth/cmd.go
+++ b/pkg/auth/cmd.go
@@ -27,7 +27,7 @@ code to authenticate the CLI tool.
 
 			var accessToken *AccessTokenResponse
 
-			switch authConfig.GrantType {
+			switch *authConfig.GrantType {
 			case DeviceCode:
 				deviceCode, err := FetchDeviceCode(cmd.Context(), *authConfig)
 				if err != nil {
@@ -63,7 +63,7 @@ code to authenticate the CLI tool.
 			cmd.Println("Successfully authenticated!")
 			cmd.Println("Your access token is valid for", validFor, "seconds.")
 
-			storageProvider := storage.NewKeyringStorage(authConfig.ClientId)
+			storageProvider := storage.NewKeyringStorage(*authConfig.ClientId)
 			if err := storageProvider.SetToken(jwt.Token{
 				Raw: accessToken.AccessToken,
 			}); err != nil {
@@ -91,7 +91,7 @@ to quickly create a Cobra application.`,
 				return
 			}
 
-			storageProvider := storage.NewKeyringStorage(authConfig.ClientId)
+			storageProvider := storage.NewKeyringStorage(*authConfig.ClientId)
 			token, err := storageProvider.GetToken()
 			if err != nil {
 				cmd.PrintErr("error fetching token: ", err)
@@ -112,7 +112,7 @@ func NewLogoutCommand(options ...Option) *cobra.Command {
 				return
 			}
 
-			storageProvider := storage.NewKeyringStorage(authConfig.ClientId)
+			storageProvider := storage.NewKeyringStorage(*authConfig.ClientId)
 			err = storageProvider.DeleteToken()
 			if err != nil {
 				cmd.PrintErr("error logging out: ", err)

--- a/pkg/auth/config.go
+++ b/pkg/auth/config.go
@@ -13,14 +13,15 @@ type Option func(*Config)
 
 // Config defines the configuration for OAuth2 device flow.
 type Config struct {
-	ClientId                    string   `json:"client_id" validate:"required"`
-	ClientSecret                string   `json:"client_secret,omitempty"`
-	DeviceAuthorizationEndpoint string   `json:"auth_url" validate:"required,url"`
-	TokenEndpoint               string   `json:"token_url" validate:"required,url"`
-	Scopes                      []string `json:"scopes" validate:"required,min=1,dive,required"`
-	Audience                    string   `json:"audience,omitempty"`
-	StorageProvider             storage.StorageProvider
-	GrantType                   GrantType `json:"grant_type"`
+	DiscoveryURL                *string   `json:"discovery_url,omitempty" validate:"omitempty,url"`
+	ClientId                    *string   `json:"client_id" validate:"required"`
+	ClientSecret                *string   `json:"client_secret,omitempty"`
+	DeviceAuthorizationEndpoint *string   `json:"auth_url" validate:"required,url"`
+	TokenEndpoint               *string   `json:"token_url" validate:"required,url"`
+	Scopes                      *[]string `json:"scopes" validate:"required,min=1,dive,required"`
+	Audience                    *string   `json:"audience,omitempty"`
+	StorageProvider             *storage.StorageProvider
+	GrantType                   *GrantType `json:"grant_type"`
 }
 
 func (c Config) IsValid() error {
@@ -35,44 +36,44 @@ func (c Config) IsValid() error {
 	return nil
 }
 
-func WithClientID(clientId string) Option {
+func WithClientID(clientId *string) Option {
 	return func(c *Config) {
 		c.ClientId = clientId
 	}
 }
 
-func WithClientSecret(clientSecret string) Option {
+func WithClientSecret(clientSecret *string) Option {
 	return func(c *Config) {
 		c.ClientSecret = clientSecret
 	}
 }
 
-func WithDeviceAuthorizationEndpoint(deviceAuthorizationEndpoint string) Option {
+func WithDeviceAuthorizationEndpoint(deviceAuthorizationEndpoint *string) Option {
 	return func(c *Config) {
 		c.DeviceAuthorizationEndpoint = deviceAuthorizationEndpoint
 	}
 }
 
-func WithTokenEndpoint(tokenEndpoint string) Option {
+func WithTokenEndpoint(tokenEndpoint *string) Option {
 	return func(c *Config) {
 		c.TokenEndpoint = tokenEndpoint
 	}
 }
 
-func WithScopes(scopes []string) Option {
+func WithScopes(scopes *[]string) Option {
 	return func(c *Config) {
 		c.Scopes = scopes
 	}
 }
 
-func WithAudience(audience string) Option {
+func WithAudience(audience *string) Option {
 	return func(c *Config) {
 		c.Audience = audience
 	}
 }
 
-func WithDiscoveryURL(discoveryURL url.URL) Option {
-	metadata, err := FetchConfigFromDiscoveryURL(discoveryURL)
+func WithDiscoveryURL(discoveryURL *url.URL) Option {
+	metadata, err := FetchConfigFromDiscoveryURL(*discoveryURL)
 	if err != nil {
 		// this is a fatal error, so we panic
 		panic(fmt.Errorf("failed to fetch OAuth2 metadata: %w", err))
@@ -85,27 +86,29 @@ func WithDiscoveryURL(discoveryURL url.URL) Option {
 	}
 
 	return func(c *Config) {
-		c.DeviceAuthorizationEndpoint = deviceAuthorizationEndpoint
-		c.TokenEndpoint = metadata.TokenEndpoint
+		c.DeviceAuthorizationEndpoint = &deviceAuthorizationEndpoint
+		c.TokenEndpoint = &metadata.TokenEndpoint
 	}
 }
 
-func WithStorageProvider(storageProvider storage.StorageProvider) Option {
+func WithStorageProvider(storageProvider *storage.StorageProvider) Option {
 	return func(c *Config) {
 		c.StorageProvider = storageProvider
 	}
 }
 
-func WithGrantType(grantType GrantType) Option {
+func WithGrantType(grantType *GrantType) Option {
 	return func(c *Config) {
 		c.GrantType = grantType
 	}
 }
 
 func configure(options ...Option) (*Config, error) {
+	scopes := strings.Split(DefaultScopes, " ")
+	grantType := DefaultGrantType
 	authConfig := &Config{
-		Scopes:    strings.Split(DefaultScopes, " "),
-		GrantType: DefaultGrantType,
+		Scopes:    &scopes,
+		GrantType: &grantType,
 	}
 
 	for _, opt := range options {

--- a/pkg/auth/config_test.go
+++ b/pkg/auth/config_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestConfig_IsValid(t *testing.T) {
+	mockStorage := storage.NewMemoryStorage("test")
 	tests := []struct {
 		name    string
 		config  Config
@@ -19,35 +20,35 @@ func TestConfig_IsValid(t *testing.T) {
 		{
 			name: "valid config",
 			config: Config{
-				ClientId:                    "client_id",
-				ClientSecret:                "client_secret",
-				DeviceAuthorizationEndpoint: "https://example.com/device",
-				TokenEndpoint:               "https://example.com/token",
-				Scopes:                      []string{"scope1", "scope2"},
-				StorageProvider:             storage.NewMemoryStorage("test"),
+				ClientId:                    strPtr("client_id"),
+				ClientSecret:                strPtr("client_secret"),
+				DeviceAuthorizationEndpoint: strPtr("https://example.com/device"),
+				TokenEndpoint:               strPtr("https://example.com/token"),
+				Scopes:                      &[]string{"scope1", "scope2"},
+				StorageProvider:             &mockStorage,
 			},
 			wantErr: false,
 		},
 		{
 			name: "missing storage provider",
 			config: Config{
-				ClientId:                    "client_id",
-				ClientSecret:                "client_secret",
-				DeviceAuthorizationEndpoint: "https://example.com/device",
-				TokenEndpoint:               "https://example.com/token",
-				Scopes:                      []string{"scope1", "scope2"},
+				ClientId:                    strPtr("client_id"),
+				ClientSecret:                strPtr("client_secret"),
+				DeviceAuthorizationEndpoint: strPtr("https://example.com/device"),
+				TokenEndpoint:               strPtr("https://example.com/token"),
+				Scopes:                      &[]string{"scope1", "scope2"},
 			},
 			wantErr: true,
 		},
 		{
 			name: "invalid URL",
 			config: Config{
-				ClientId:                    "client_id",
-				ClientSecret:                "client_secret",
-				DeviceAuthorizationEndpoint: "invalid-url",
-				TokenEndpoint:               "https://example.com/token",
-				Scopes:                      []string{"scope1", "scope2"},
-				StorageProvider:             storage.NewMemoryStorage("test"),
+				ClientId:                    strPtr("client_id"),
+				ClientSecret:                strPtr("client_secret"),
+				DeviceAuthorizationEndpoint: strPtr("invalid-url"),
+				TokenEndpoint:               strPtr("https://example.com/token"),
+				Scopes:                      &[]string{"scope1", "scope2"},
+				StorageProvider:             &mockStorage,
 			},
 			wantErr: true,
 		},
@@ -88,25 +89,26 @@ func TestWithOptions(t *testing.T) {
 	metadata, err := FetchConfigFromDiscoveryURL(*discoveryURL)
 	assert.NoError(t, err)
 
+	mockStorage := storage.NewMemoryStorage("test")
 	config, err := configure(
-		WithDiscoveryURL(*discoveryURL),
-		WithClientID("client_id"),
-		WithClientSecret("client_secret"),
-		WithDeviceAuthorizationEndpoint("https://example.com/device"),
-		WithTokenEndpoint("https://example.com/token"),
-		WithScopes([]string{"scope1", "scope2"}),
-		WithAudience("audience"),
-		WithStorageProvider(storage.NewMemoryStorage("test")),
+		WithDiscoveryURL(discoveryURL),
+		WithClientID(strPtr("client_id")),
+		WithClientSecret(strPtr("client_secret")),
+		WithDeviceAuthorizationEndpoint(strPtr("https://example.com/device")),
+		WithTokenEndpoint(strPtr("https://example.com/token")),
+		WithScopes(&[]string{"scope1", "scope2"}),
+		WithAudience(strPtr("audience")),
+		WithStorageProvider(&mockStorage),
 	)
 
 	assert.NoError(t, err)
-	assert.Equal(t, "client_id", config.ClientId)
-	assert.Equal(t, "client_secret", config.ClientSecret)
-	assert.Equal(t, "https://example.com/device", config.DeviceAuthorizationEndpoint)
-	assert.Equal(t, "https://example.com/token", config.TokenEndpoint)
-	assert.Equal(t, []string{"scope1", "scope2"}, config.Scopes)
-	assert.Equal(t, "audience", config.Audience)
-	assert.NotNil(t, config.StorageProvider)
+	assert.Equal(t, "client_id", *config.ClientId)
+	assert.Equal(t, "client_secret", *config.ClientSecret)
+	assert.Equal(t, "https://example.com/device", *config.DeviceAuthorizationEndpoint)
+	assert.Equal(t, "https://example.com/token", *config.TokenEndpoint)
+	assert.Equal(t, []string{"scope1", "scope2"}, *config.Scopes)
+	assert.Equal(t, "audience", *config.Audience)
+	assert.NotNil(t, *config.StorageProvider)
 	assert.Equal(t, "https://example.com", metadata.Issuer)
 	assert.Equal(t, "https://example.com/auth", metadata.AuthorizationEndpoint)
 	assert.Equal(t, "https://example.com/token", metadata.TokenEndpoint)

--- a/pkg/auth/device_code.go
+++ b/pkg/auth/device_code.go
@@ -27,18 +27,18 @@ type DeviceAuthResponse struct {
 func FetchDeviceCode(ctx context.Context, config Config) (*DeviceAuthResponse, error) {
 	// Prepare the request payload
 	payload := map[string]string{
-		"client_id": config.ClientId,
-		"scope":     joinScopes(config.Scopes),
+		"client_id": *config.ClientId,
+		"scope":     joinScopes(*config.Scopes),
 	}
 
 	// Add optional audience
-	if config.Audience != "" {
-		payload["audience"] = config.Audience
+	if config.Audience != nil {
+		payload["audience"] = *config.Audience
 	}
 
 	// Add optional client secret
-	if config.ClientSecret != "" {
-		payload["client_secret"] = config.ClientSecret
+	if config.ClientSecret != nil {
+		payload["client_secret"] = *config.ClientSecret
 	}
 
 	// Serialize the payload to form-encoded format
@@ -48,7 +48,7 @@ func FetchDeviceCode(ctx context.Context, config Config) (*DeviceAuthResponse, e
 	}
 
 	// Create HTTP request
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, config.DeviceAuthorizationEndpoint, bytes.NewBufferString(formData.Encode()))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, *config.DeviceAuthorizationEndpoint, bytes.NewBufferString(formData.Encode()))
 	if err != nil {
 		return nil, fmt.Errorf("%w: failed to create HTTP request", ErrInternal)
 	}


### PR DESCRIPTION
This pull request includes several changes aimed at improving the flexibility and robustness of the OAuth2 configuration and usage within the codebase. The primary focus is on converting configuration fields from basic types to pointers, allowing for better handling of optional and default values.

### Changes to Configuration Handling:

* [`pkg/auth/config.go`](diffhunk://#diff-a055f299d1537638822e01418b4740b015220e0d6ea6abc51691b41b22ca650cL16-R24): Updated the `Config` struct to use pointer types for fields such as `ClientId`, `ClientSecret`, `DeviceAuthorizationEndpoint`, `TokenEndpoint`, `Scopes`, `Audience`, `StorageProvider`, and `GrantType`. This change allows these fields to be optional and simplifies the handling of default values.
* [`pkg/auth/config.go`](diffhunk://#diff-a055f299d1537638822e01418b4740b015220e0d6ea6abc51691b41b22ca650cL38-R76): Modified various `With*` functions to accept pointers, aligning with the updated `Config` struct. This includes functions like `WithClientID`, `WithClientSecret`, `WithDeviceAuthorizationEndpoint`, `WithTokenEndpoint`, `WithScopes`, `WithAudience`, `WithDiscoveryURL`, `WithStorageProvider`, and `WithGrantType`. [[1]](diffhunk://#diff-a055f299d1537638822e01418b4740b015220e0d6ea6abc51691b41b22ca650cL38-R76) [[2]](diffhunk://#diff-a055f299d1537638822e01418b4740b015220e0d6ea6abc51691b41b22ca650cL88-R111)

### Changes to Example Commands:

* [`examples/basic/cmd/root.go`](diffhunk://#diff-e362c984c0694ce3ebfa3c74c7f514be6645fab8cdf35922c190bb18049e60bbL33-R33): Changed `CLIENT_ID` from a constant to a variable and updated its usage to pass pointers where required. [[1]](diffhunk://#diff-e362c984c0694ce3ebfa3c74c7f514be6645fab8cdf35922c190bb18049e60bbL33-R33) [[2]](diffhunk://#diff-e362c984c0694ce3ebfa3c74c7f514be6645fab8cdf35922c190bb18049e60bbL60-R62)
* [`examples/client_credentials/cmd/root.go`](diffhunk://#diff-9874270b0053228c887766b6ecf8e02981e4348ae7d0ba476f699432fc07c3a1L33-R34): Similarly, changed `CLIENT_ID` and `CLIENT_SECRET` from constants to variables and updated their usage to pass pointers. [[1]](diffhunk://#diff-9874270b0053228c887766b6ecf8e02981e4348ae7d0ba476f699432fc07c3a1L33-R34) [[2]](diffhunk://#diff-9874270b0053228c887766b6ecf8e02981e4348ae7d0ba476f699432fc07c3a1R60-R66)

### Changes to Authentication Logic:

* [`pkg/auth/access_token.go`](diffhunk://#diff-7e446103754692978f64fcbefc38c09dfa532ad34e37cde3040ab9c087d2fbbeL23-R29): Updated the `PollForAccessToken` function to use pointer dereferencing for `ClientId`, `ClientSecret`, and `TokenEndpoint` fields in the `Config` struct. [[1]](diffhunk://#diff-7e446103754692978f64fcbefc38c09dfa532ad34e37cde3040ab9c087d2fbbeL23-R29) [[2]](diffhunk://#diff-7e446103754692978f64fcbefc38c09dfa532ad34e37cde3040ab9c087d2fbbeL45-R45) [[3]](diffhunk://#diff-7e446103754692978f64fcbefc38c09dfa532ad34e37cde3040ab9c087d2fbbeL77-R77)
* [`pkg/auth/client_credentials.go`](diffhunk://#diff-51d09ee5062eec1fa076cd900c5fb62cdaf1756e67d27c19476bbdf1e3bddba8L16-R29): Modified the `FetchClientCredentialsToken` function to use pointer dereferencing for `ClientId`, `ClientSecret`, `TokenEndpoint`, `Scopes`, and `Audience` fields in the `Config` struct.

### Changes to Command Execution:

* [`pkg/auth/cmd.go`](diffhunk://#diff-f31440ef1a31dda14545688e1da267ac0f9db7c5a3e65f7e1585a445d50ccefaL30-R30): Updated various command functions to use pointer dereferencing for `ClientId` and `GrantType` fields in the `Config` struct, ensuring consistent handling of these fields. [[1]](diffhunk://#diff-f31440ef1a31dda14545688e1da267ac0f9db7c5a3e65f7e1585a445d50ccefaL30-R30) [[2]](diffhunk://#diff-f31440ef1a31dda14545688e1da267ac0f9db7c5a3e65f7e1585a445d50ccefaL66-R66) [[3]](diffhunk://#diff-f31440ef1a31dda14545688e1da267ac0f9db7c5a3e65f7e1585a445d50ccefaL94-R94) [[4]](diffhunk://#diff-f31440ef1a31dda14545688e1da267ac0f9db7c5a3e65f7e1585a445d50ccefaL115-R115)

### Changes to Tests:

* [`pkg/auth/config_test.go`](diffhunk://#diff-b461fbcdaeec7252cc253366b4ebfc89f7c5351762ebdad1f7c54ffc9ae08f8fR14): Updated tests to accommodate the changes in the `Config` struct, including the use of helper functions like `strPtr` to create string pointers and updating mock storage provider initialization. [[1]](diffhunk://#diff-b461fbcdaeec7252cc253366b4ebfc89f7c5351762ebdad1f7c54ffc9ae08f8fR14) [[2]](diffhunk://#diff-b461fbcdaeec7252cc253366b4ebfc89f7c5351762ebdad1f7c54ffc9ae08f8fL22-R51) [[3]](diffhunk://#diff-b461fbcdaeec7252cc253366b4ebfc89f7c5351762ebdad1f7c54ffc9ae08f8fR92-R111)
* [`pkg/auth/access_token_test.go`](diffhunk://#diff-8399066923a76109cc060cb01bde2757cf090e0b4c75714a1c4af15e1c3cb682L44-R46): Added a helper function `strPtr` to create string pointers and updated the `TestPollForAccessToken` function to use these pointers. [[1]](diffhunk://#diff-8399066923a76109cc060cb01bde2757cf090e0b4c75714a1c4af15e1c3cb682L44-R46) [[2]](diffhunk://#diff-8399066923a76109cc060cb01bde2757cf090e0b4c75714a1c4af15e1c3cb682R67-R70)

These changes collectively enhance the flexibility and robustness of the OAuth2 configuration and usage, making the codebase more adaptable to different scenarios and configurations.